### PR TITLE
Added component automation class

### DIFF
--- a/limbus_components/base/auto_component.py
+++ b/limbus_components/base/auto_component.py
@@ -60,8 +60,3 @@ class ComponentFactory(Component):
             setattr(comp, "return_annotation", return_annotation)
             return comp
         return f
-
-
-if __name__ == "__main__":
-    import kornia
-    auto_generate_doc_from_function(kornia.enhance.equalize_clahe)

--- a/limbus_components/base/auto_component.py
+++ b/limbus_components/base/auto_component.py
@@ -1,0 +1,67 @@
+from typing import Callable
+import inspect
+import asyncio
+
+from limbus.core import Component, ComponentState
+
+
+def extract_function_signature(function: Callable):
+    sig = inspect.signature(function)
+    parameters = sig.parameters
+    return_annotation = sig.return_annotation
+    return parameters, return_annotation
+
+
+def auto_generate_doc_from_function(function: Callable):
+    new_doc = f"""
+    Original documentation
+    ----------------------
+    {function.__doc__}
+    """
+    return new_doc
+
+
+class AutoComponent(Component):
+    async def forward(self) -> ComponentState:
+        input_values = await asyncio.gather(
+            *[getattr(self._inputs, param).receive() for param in self.parameters.keys()]
+        )
+        out = self._callable(
+            **{k:v for k, v in zip(self.parameters.keys(), input_values)}
+        )
+        await self._outputs.out.send(out)
+        return ComponentState.OK
+
+
+class ComponentFactory(Component):
+    """Register Limbus component automatically."""
+
+    @staticmethod
+    def from_function(function: Callable) -> Component:
+        parameters, return_annotation = extract_function_signature(function)
+
+        def f(name: str):
+            comp = AutoComponent(name)
+            comp.__doc__ = auto_generate_doc_from_function(function)
+            for value in parameters.values():
+                if value.default == inspect._empty:
+                    comp.inputs.declare(value.name, value.annotation)
+                else:
+                    comp.inputs.declare(value.name, value.annotation, value.default)
+            comp.outputs.declare("out", return_annotation)
+
+            input_cls_annotations = {value.name: value.annotation for value in parameters.values()}
+            output_cls_annotations = {"out": return_annotation}
+            comp._inputs.__annotations__ = input_cls_annotations
+            comp._outputs.__annotations__ = output_cls_annotations
+
+            setattr(comp, "_callable", function)
+            setattr(comp, "parameters", parameters)
+            setattr(comp, "return_annotation", return_annotation)
+            return comp
+        return f
+
+
+if __name__ == "__main__":
+    import kornia
+    auto_generate_doc_from_function(kornia.enhance.equalize_clahe)

--- a/limbus_components/kornia/enhance/adjust.py
+++ b/limbus_components/kornia/enhance/adjust.py
@@ -1,0 +1,7 @@
+import kornia
+from limbus_components.base.auto_component import ComponentFactory
+
+AdjustHue = ComponentFactory.from_function(kornia.enhance.adjust.adjust_hue)
+AdjustBrightness = ComponentFactory.from_function(kornia.enhance.adjust.adjust_brightness)
+AdjustContrast = ComponentFactory.from_function(kornia.enhance.adjust.adjust_contrast)
+AdjustSaturation = ComponentFactory.from_function(kornia.enhance.adjust.adjust_saturation)


### PR DESCRIPTION
This can be used to convert some kornia or pytorch functions into Limbus components automatically without much efforts.

In the future, we may also have ```ComponentFactory.from_nn_module``` to enable more the support of nn modules.

Ideally, we may use this automation to populate the Limbus components very quick and easily. Not sure if to put it into this repo or the main Limbus repo. You may decide.